### PR TITLE
add 'get mime type'

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,6 +13,7 @@
   import GithubIcon from "./components/icons/github.icon.svelte";
   import { patchBlob } from "./utils/blobHelpers";
   import SidebarLayoutSection from "./components/SidebarLayoutSection.svelte";
+  import { getPreferredMimeType } from "./utils/getPreferredMimeType";
 
   let recorder: MediaRecorder;
   const chunks: Blob[] = [];
@@ -59,7 +60,7 @@
     recorder = new MediaRecorder(combinedStream, {
       audioBitsPerSecond: 128000, // 128 kbps
       videoBitsPerSecond: 10 * 1000 * 1000, // N mbps
-      mimeType: "video/webm;codecs=vp9",
+      mimeType: getPreferredMimeType(),
     });
     recorder.ondataavailable = onDataAvailable;
     recorder.onstop = onRecorderStop;

--- a/src/utils/getPreferredMimeType.ts
+++ b/src/utils/getPreferredMimeType.ts
@@ -1,0 +1,37 @@
+export const getPreferredMimeType = () => {
+  const mediaTypes = ["video", "audio"];
+  const FILE_EXTENSIONS = ["webm", "ogg", "mp4", "x-matroska"];
+  const CODECS = [
+    "vp9",
+    "vp9.0",
+    "vp8",
+    "vp8.0",
+    "avc1",
+    "av1",
+    "h265",
+    "h.265",
+    "h264",
+    "h.264",
+    "opus",
+  ];
+
+  // Create a list of supported mimetypes with the original codec options
+  var mimetypes = [
+    ...new Set(
+      FILE_EXTENSIONS.flatMap((ext) =>
+        CODECS.flatMap((codec) =>
+          mediaTypes.flatMap((mediaType) => [
+            `${mediaType}/${ext};codecs:${codec}`,
+            `${mediaType}/${ext};codecs=${codec}`,
+            `${mediaType}/${ext};codecs:${codec.toUpperCase()}`,
+            `${mediaType}/${ext};codecs=${codec.toUpperCase()}`,
+            `${mediaType}/${ext}`,
+          ])
+        )
+      )
+    ),
+  ].filter((variation) => MediaRecorder.isTypeSupported(variation));
+
+  // Return the first mimetype from the list of supported mimetypes
+  return mimetypes[0];
+};


### PR DESCRIPTION
Gets a supported mimeType so screen recordings can save on Safari and Firefox

https://github.com/FormidableLabs/clips/issues/9