### PR TITLE
Let's support Safari (I guess)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,9 +13,11 @@
   import GithubIcon from "./components/icons/github.icon.svelte";
   import { patchBlob } from "./utils/blobHelpers";
   import SidebarLayoutSection from "./components/SidebarLayoutSection.svelte";
+  import { getPreferredMimeType } from "./utils/getPreferredMimeType";
 
   let recorder: MediaRecorder;
   const chunks: Blob[] = [];
+  let ext: string = "";
   const onDataAvailable = (e: BlobEvent) => {
     chunks.push(e.data);
   };
@@ -32,7 +34,7 @@
 
     const link = document.createElement("a");
     link.href = data;
-    link.download = "video.webm";
+    link.download = `video.${ext}`;
     link.dispatchEvent(
       new MouseEvent("click", {
         bubbles: true,
@@ -56,10 +58,12 @@
       ...($micState.stream?.getTracks() || []),
     ]);
     // TODO: dynamic bits per second based on resolution...
+    const mime = getPreferredMimeType();
+    ext = mime.ext;
     recorder = new MediaRecorder(combinedStream, {
       audioBitsPerSecond: 128000, // 128 kbps
       videoBitsPerSecond: 10 * 1000 * 1000, // N mbps
-      mimeType: "video/webm;codecs=vp9",
+      mimeType: mime.mimeType,
     });
     recorder.ondataavailable = onDataAvailable;
     recorder.onstop = onRecorderStop;

--- a/src/components/WebcamButton.svelte
+++ b/src/components/WebcamButton.svelte
@@ -98,7 +98,7 @@
             <TextButton
               on:click={stopWebcam}
               extraClasses="bg-fmd-gray_lighter w-full"
-              hasClose>Stop Mic</TextButton
+              hasClose>Stop Webcam</TextButton
             >
           </div>
         {/if}
@@ -109,7 +109,7 @@
   <Camera />
 
   <video
-    class="invisible absolute"
+    class="absolute w-1 h-1 opacity-0 z-[-10] pointer-events-none"
     bind:this={$webcamState.preview}
     autoplay
     playsinline

--- a/src/utils/getPreferredMimeType.ts
+++ b/src/utils/getPreferredMimeType.ts
@@ -2,7 +2,6 @@ export const getPreferredMimeType = () => {
   return MIME_TYPES.find(mimeType => MediaRecorder.isTypeSupported(mimeType.mimeType));
 };
 
-
 const MEDIA_TYPES = ["video"];
 const FILE_EXTENSIONS = ["mp4", "webm", "ogg", "x-matroska"];
 const CODECS = [
@@ -19,8 +18,7 @@ const CODECS = [
   "opus"
 ];
 
-
-const MIME_TYPES = [...new Set(
+const MIME_TYPES: { mimeType: string; ext: string }[] = [...new Set(
   FILE_EXTENSIONS.flatMap(ext => CODECS.flatMap(codec => MEDIA_TYPES.flatMap(mediaType => [
     { mimeType: `${mediaType}/${ext};codecs:${codec}`, ext },
     { mimeType: `${mediaType}/${ext};codecs=${codec}`, ext },

--- a/src/utils/getPreferredMimeType.ts
+++ b/src/utils/getPreferredMimeType.ts
@@ -1,0 +1,31 @@
+export const getPreferredMimeType = () => {
+  return MIME_TYPES.find(mimeType => MediaRecorder.isTypeSupported(mimeType.mimeType));
+};
+
+
+const MEDIA_TYPES = ["video"];
+const FILE_EXTENSIONS = ["mp4", "webm", "ogg", "x-matroska"];
+const CODECS = [
+  "vp9",
+  "vp9.0",
+  "vp8",
+  "vp8.0",
+  "avc1",
+  "av1",
+  "h265",
+  "h.265",
+  "h264",
+  "h.264",
+  "opus"
+];
+
+
+const MIME_TYPES = [...new Set(
+  FILE_EXTENSIONS.flatMap(ext => CODECS.flatMap(codec => MEDIA_TYPES.flatMap(mediaType => [
+    { mimeType: `${mediaType}/${ext};codecs:${codec}`, ext },
+    { mimeType: `${mediaType}/${ext};codecs=${codec}`, ext },
+    { mimeType: `${mediaType}/${ext};codecs:${codec.toUpperCase()}`, ext },
+    { mimeType: `${mediaType}/${ext};codecs=${codec.toUpperCase()}`, ext },
+    { mimeType: `${mediaType}/${ext}`, ext }
+  ])))
+)];


### PR DESCRIPTION
This PR does a dynamic mimeType lookup based on browser to support Safari (and other non-chromium browsers). Interestingly, webkit is the only browser that supports `.mp4` recording which is IMO the ideal output format. That means, `clips` might be best run on Safari. Address #9 